### PR TITLE
Restore ARMv7 release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,33 @@ jobs:
       - name: Build and test
         run: make test
 
+  static:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            name: amd64
+          - platform: linux/arm64
+            name: arm64
+          - platform: linux/arm/v7
+            name: armv7
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-qemu-action@v4
+
       - uses: docker/setup-buildx-action@v4
 
       - name: Build static Linux binary
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64
+          platforms: ${{ matrix.platform }}
           target: release
           outputs: type=local,dest=dist
 
       - name: Verify static Linux binary
         run: |
-          file dist/rtlmux-linux-amd64
-          file dist/rtlmux-linux-amd64 | grep -q "statically linked"
+          file "dist/rtlmux-linux-${{ matrix.name }}"
+          file "dist/rtlmux-linux-${{ matrix.name }}" | grep -q "statically linked"

--- a/rtlmux.c
+++ b/rtlmux.c
@@ -93,7 +93,7 @@ static void removeClient(struct client *client) {
   }
 }
 
-void releaseDataRef(const void *d, unsigned long len, void *ptr) {
+void releaseDataRef(const void *d, size_t len, void *ptr) {
   (void)d;
   (void)len;
   struct rtlData *data = (struct rtlData *)ptr;


### PR DESCRIPTION
## Summary

- use the libevent callback length type portably on 32-bit ARM
- build every release architecture in pull request CI so ARM regressions are caught before merge

## Context

The first post-merge Docker Hub publish exposed an ARMv7-only `evbuffer_add_reference` callback type mismatch. amd64 and arm64 use an `unsigned long`-sized `size_t`, while ARMv7 uses `unsigned int`.

## Validation

- `make test`
- CI static build matrix for amd64, arm64, and ARMv7