### PR TITLE
Update project copyright dates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Stephen Olesen
+Copyright (c) 2016-2026 Stephen Olesen
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/cmdline.c
+++ b/cmdline.c
@@ -29,7 +29,7 @@ const char *gengetopt_args_info_purpose = "Relay RTL TCP data to multiple client
 
 const char *gengetopt_args_info_usage = "Usage: rtlmux [OPTIONS]...";
 
-const char *gengetopt_args_info_versiontext = "(c) 2016 Stephen Olesen";
+const char *gengetopt_args_info_versiontext = "(c) 2016-2026 Stephen Olesen";
 
 const char *gengetopt_args_info_description = "This will connect to an rtl_tcp server and allow multiple end clients to\nconnect and control the RTL.";
 

--- a/options.ggo
+++ b/options.ggo
@@ -3,7 +3,7 @@ version "1.0.0"
 purpose "Relay RTL TCP data to multiple clients."
 description "This will connect to an rtl_tcp server and allow multiple end clients to connect and control the RTL."
 
-versiontext "(c) 2016 Stephen Olesen"
+versiontext "(c) 2016-2026 Stephen Olesen"
 
 option "port" p "rtl_tcp port"
   int typestr="port" default="1234" optional


### PR DESCRIPTION
## Summary

- update project-owned copyright notices from 2016 to 2016-2026
- keep the generated command-line version text aligned with `options.ggo`
- preserve the third-party slog attribution unchanged

## Validation

- `make test`
- `./rtlmux --version`