### PR TITLE
Filter internal release build artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
+          pattern: rtlmux-linux-*
           merge-multiple: true
 
       - name: Create checksums


### PR DESCRIPTION
## Summary

- download only explicitly named `rtlmux-linux-*` artifacts in the release job
- prevent Docker BuildKit diagnostic records from being attached to future GitHub releases

## Validation

- release workflow YAML parses successfully
- artifact pattern resolves only the three binary artifacts
- `make test`