### PR TITLE
Sync the Docker Hub overview

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,0 +1,30 @@
+name: Docker Hub Overview
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - README.md
+      - .github/workflows/dockerhub-description.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Update Docker Hub overview
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: slepp/rtlmux
+          short-description: Lightweight RTL TCP multiplexer for sharing one SDR stream with multiple LAN clients.
+          readme-filepath: ./README.md
+          enable-url-completion: true


### PR DESCRIPTION
## Summary

- publish `README.md` as the Docker Hub repository overview
- set a concise Docker Hub search description
- refresh automatically when the README or sync workflow changes
- pin the Docker Hub description action to the latest immutable release SHA

## Validation

- workflow YAML parses successfully
- all action references use full commit SHAs
- short description is within Docker Hub's 100-character limit